### PR TITLE
radiusUnits prop to ScatterplotLayer

### DIFF
--- a/docs/layers/geojson-layer.md
+++ b/docs/layers/geojson-layer.md
@@ -181,6 +181,12 @@ Elevation multiplier. The final elevation is calculated by
   `elevationScale * getElevation(d)`. `elevationScale` is a handy property to scale
 all polygon elevation without updating the data.
 
+##### `radiusUnits` (String, optional)
+
+* Default: `'meters'`
+
+The units of the point radius, one of `'meters'`, `'pixels'`. When zooming in and out, meter sizes scale with the base map, and pixel sizes remain the same on screen.
+
 ##### `pointRadiusScale` (Number, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `1`
@@ -234,7 +240,7 @@ Note: This accessor is only called for `Polygon` and `MultiPolygon` and `Point` 
 
 * Default: `1`
 
-The radius of `Point` and `MultiPoint` feature, in meters.
+The radius of `Point` and `MultiPoint` feature. In units specified by `radiusUnits` (default meters).
 
 * If a number is provided, it is used as the radius for all point features.
 * If a function is provided, it is called on each point feature to retrieve its radius.

--- a/docs/layers/geojson-layer.md
+++ b/docs/layers/geojson-layer.md
@@ -181,7 +181,7 @@ Elevation multiplier. The final elevation is calculated by
   `elevationScale * getElevation(d)`. `elevationScale` is a handy property to scale
 all polygon elevation without updating the data.
 
-##### `radiusUnits` (String, optional)
+##### `pointRadiusUnits` (String, optional)
 
 * Default: `'meters'`
 
@@ -240,7 +240,7 @@ Note: This accessor is only called for `Polygon` and `MultiPolygon` and `Point` 
 
 * Default: `1`
 
-The radius of `Point` and `MultiPoint` feature. In units specified by `radiusUnits` (default meters).
+The radius of `Point` and `MultiPoint` feature. In units specified by `pointRadiusUnits` (default meters).
 
 * If a number is provided, it is used as the radius for all point features.
 * If a function is provided, it is called on each point feature to retrieve its radius.

--- a/docs/layers/scatterplot-layer.md
+++ b/docs/layers/scatterplot-layer.md
@@ -83,6 +83,12 @@ Inherits from all [Base Layer](/docs/api-reference/layer.md) properties.
 
 ### Render Options
 
+##### `radiusUnits` (String, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
+
+* Default: `'meters'`
+
+The units of the point radius, one of `'meters'`, `'pixels'`. When zooming in and out, meter sizes scale with the base map, and pixel sizes remain the same on screen.
+
 ##### `radiusScale` (Number, optional) ![transition-enabled](https://img.shields.io/badge/transition-enabled-green.svg?style=flat-square")
 
 * Default: `1`
@@ -150,7 +156,7 @@ Method called to retrieve the position of each object.
 
 * Default: `1`
 
-The radius of each object, in meters.
+The radius of each object, in units specified by `radiusUnits` (default meters).
 
 * If a number is provided, it is used as the radius for all objects.
 * If a function is provided, it is called on each object to retrieve its radius.

--- a/modules/layers/src/geojson-layer/geojson-layer.js
+++ b/modules/layers/src/geojson-layer/geojson-layer.js
@@ -45,6 +45,7 @@ const defaultProps = {
 
   elevationScale: 1,
 
+  radiusUnits: 'meters',
   pointRadiusScale: 1,
   pointRadiusMinPixels: 0, //  min point radius in pixels
   pointRadiusMaxPixels: Number.MAX_SAFE_INTEGER, // max point radius in pixels
@@ -132,6 +133,7 @@ export default class GeoJsonLayer extends CompositeLayer {
       lineWidthMaxPixels,
       lineJointRounded,
       lineMiterLimit,
+      radiusUnits,
       pointRadiusScale,
       pointRadiusMinPixels,
       pointRadiusMaxPixels,
@@ -279,6 +281,7 @@ export default class GeoJsonLayer extends CompositeLayer {
 
           stroked,
           filled,
+          radiusUnits,
           radiusScale: pointRadiusScale,
           radiusMinPixels: pointRadiusMinPixels,
           radiusMaxPixels: pointRadiusMaxPixels,

--- a/modules/layers/src/geojson-layer/geojson-layer.js
+++ b/modules/layers/src/geojson-layer/geojson-layer.js
@@ -45,7 +45,7 @@ const defaultProps = {
 
   elevationScale: 1,
 
-  radiusUnits: 'meters',
+  pointRadiusUnits: 'meters',
   pointRadiusScale: 1,
   pointRadiusMinPixels: 0, //  min point radius in pixels
   pointRadiusMaxPixels: Number.MAX_SAFE_INTEGER, // max point radius in pixels
@@ -133,7 +133,7 @@ export default class GeoJsonLayer extends CompositeLayer {
       lineWidthMaxPixels,
       lineJointRounded,
       lineMiterLimit,
-      radiusUnits,
+      pointRadiusUnits,
       pointRadiusScale,
       pointRadiusMinPixels,
       pointRadiusMaxPixels,
@@ -281,7 +281,7 @@ export default class GeoJsonLayer extends CompositeLayer {
 
           stroked,
           filled,
-          radiusUnits,
+          radiusUnits: pointRadiusUnits,
           radiusScale: pointRadiusScale,
           radiusMinPixels: pointRadiusMinPixels,
           radiusMaxPixels: pointRadiusMaxPixels,

--- a/modules/layers/src/scatterplot-layer/scatterplot-layer.js
+++ b/modules/layers/src/scatterplot-layer/scatterplot-layer.js
@@ -28,6 +28,7 @@ import fs from './scatterplot-layer-fragment.glsl';
 const DEFAULT_COLOR = [0, 0, 0, 255];
 
 const defaultProps = {
+  radiusUnits: 'meters',
   radiusScale: {type: 'number', min: 0, value: 1},
   radiusMinPixels: {type: 'number', min: 0, value: 0}, //  min point radius in pixels
   radiusMaxPixels: {type: 'number', min: 0, value: Number.MAX_SAFE_INTEGER}, // max point radius in pixels
@@ -112,6 +113,7 @@ export default class ScatterplotLayer extends Layer {
   draw({uniforms}) {
     const {viewport} = this.context;
     const {
+      radiusUnits,
       radiusScale,
       radiusMinPixels,
       radiusMaxPixels,
@@ -123,17 +125,18 @@ export default class ScatterplotLayer extends Layer {
       lineWidthMaxPixels
     } = this.props;
 
-    const widthMultiplier = lineWidthUnits === 'pixels' ? viewport.metersPerPixel : 1;
+    const pointRadiusMultiplier = radiusUnits === 'pixels' ? viewport.metersPerPixel : 1;
+    const lineWidthMultiplier = lineWidthUnits === 'pixels' ? viewport.metersPerPixel : 1;
 
     this.state.model
       .setUniforms(uniforms)
       .setUniforms({
         stroked: stroked ? 1 : 0,
         filled,
-        radiusScale,
+        radiusScale: radiusScale * pointRadiusMultiplier,
         radiusMinPixels,
         radiusMaxPixels,
-        lineWidthScale: lineWidthScale * widthMultiplier,
+        lineWidthScale: lineWidthScale * lineWidthMultiplier,
         lineWidthMinPixels,
         lineWidthMaxPixels
       })

--- a/test/modules/layers/index.js
+++ b/test/modules/layers/index.js
@@ -33,3 +33,4 @@ import './text-layer/lru-cache.spec';
 import './text-layer/text-layer.spec';
 import './column-geometry.spec';
 import './utils.spec';
+import './scatterplot-layer.spec';

--- a/test/modules/layers/scatterplot-layer.spec.js
+++ b/test/modules/layers/scatterplot-layer.spec.js
@@ -1,0 +1,45 @@
+import test from 'tape-catch';
+import {testLayer} from '@deck.gl/test-utils';
+import {GeoJsonLayer} from '@deck.gl/layers';
+import * as FIXTURES from 'deck.gl-test/data';
+
+const SIZE = 1;
+
+test('ScatterplotLayer points size by radiusUnits prop', t => {
+  const testCases = [
+    {
+      props: {
+        data: FIXTURES.geojson,
+        getSize: SIZE,
+        radiusUnits: 'meters'
+      },
+      onAfterUpdate: ({subLayers}) => {
+        const filteredLayers = subLayers.filter(l => l.id === 'GeoJsonLayer-points');
+        t.ok(filteredLayers.length === 1);
+
+        const scatterplotLayer = filteredLayers[0];
+        const uniforms = scatterplotLayer.getModels()[0].getUniforms();
+        t.ok(uniforms.radiusScale === SIZE);
+      }
+    },
+    {
+      props: {
+        data: FIXTURES.geojson,
+        getSize: SIZE,
+        radiusUnits: 'pixels'
+      },
+      onAfterUpdate: ({subLayers}) => {
+        const filteredLayers = subLayers.filter(l => l.id === 'GeoJsonLayer-points');
+        t.ok(filteredLayers.length === 1);
+
+        const scatterplotLayer = filteredLayers[0];
+        const uniforms = scatterplotLayer.getModels()[0].getUniforms();
+        const {viewport} = scatterplotLayer.context;
+        t.ok(uniforms.radiusScale === SIZE * viewport.metersPerPixel);
+      }
+    }
+  ];
+
+  testLayer({Layer: GeoJsonLayer, testCases, onError: t.notOk});
+  t.end();
+});

--- a/test/modules/layers/scatterplot-layer.spec.js
+++ b/test/modules/layers/scatterplot-layer.spec.js
@@ -11,7 +11,7 @@ test('ScatterplotLayer points size by radiusUnits prop', t => {
       props: {
         data: FIXTURES.geojson,
         getSize: SIZE,
-        radiusUnits: 'meters'
+        pointRadiusUnits: 'meters'
       },
       onAfterUpdate: ({subLayers}) => {
         const filteredLayers = subLayers.filter(l => l.id === 'GeoJsonLayer-points');
@@ -26,7 +26,7 @@ test('ScatterplotLayer points size by radiusUnits prop', t => {
       props: {
         data: FIXTURES.geojson,
         getSize: SIZE,
-        radiusUnits: 'pixels'
+        pointRadiusUnits: 'pixels'
       },
       onAfterUpdate: ({subLayers}) => {
         const filteredLayers = subLayers.filter(l => l.id === 'GeoJsonLayer-points');


### PR DESCRIPTION
The objective of this PR is to add points by pixels (in addition to the current meters options) to the ScatterPlot layer.

In the same way as `lineWidthUnits` works for lines, this PR adds `pointRadiusUnits` for points. Also, the same options: `meters` and `pixels`, with `meters` as default one.

**Why?** wight now, if you want to have points with the very same size in every zoom: you will see how a new layer is drawn

![points-deck](https://user-images.githubusercontent.com/421145/83274105-9649ad80-a1cd-11ea-86c1-38e2b2e39adf.gif)

Using `pointRadiusUnits: "pixels"`:

![points-deck2](https://user-images.githubusercontent.com/421145/83275905-1cff8a00-a1d0-11ea-9c72-a1ca8915a4fd.gif)
 