### PR TITLE
Feature/ch105051/unique

### DIFF
--- a/docs/api-reference/carto/carto-bqtiler-layer.md
+++ b/docs/api-reference/carto/carto-bqtiler-layer.md
@@ -56,6 +56,11 @@ new deck.carto.CartoBQTilerLayer({});
 
 ## Properties
 
+##### `uniqueIdProperty` (String | Number)
+
+
+Optional. An string or number pointing to a tile attribute containing a unique identifier for features across tiles. If not, [feature id](https://github.com/mapbox/vector-tile-spec/tree/master/2.1#42-features) will be used.
+
 
 ##### `data` (String)
 

--- a/docs/api-reference/carto/carto-sql-layer.md
+++ b/docs/api-reference/carto/carto-sql-layer.md
@@ -58,6 +58,11 @@ new deck.carto.CartoSQLLayer({});
 
 ## Properties
 
+##### `uniqueIdProperty` (String | Number)
+
+* Default: `cartodb_id`
+
+Optional. An string or number pointing to a tile attribute containing a unique identifier for features across tiles.
 
 ##### `data` (String)
 

--- a/examples/get-started/pure-js/carto/app.js
+++ b/examples/get-started/pure-js/carto/app.js
@@ -76,7 +76,9 @@ function render() {
       pointRadiusScale: 2000,
       getRadius: f => 11 - f.properties.scalerank,
       getFillColor: [200, 0, 80, 180],
-      autoHighlight: true
+      autoHighlight: true,
+      highlightColor: [0, 0, 128, 128],
+      pickable: true
     }),
     new CartoBQTilerLayer({
       id: 'osm_buildings',

--- a/modules/carto/src/layers/carto-layer.js
+++ b/modules/carto/src/layers/carto-layer.js
@@ -24,11 +24,17 @@ export default class CartoLayer extends CompositeLayer {
     throw new Error(`You must use one of the specific carto layers: BQ or SQL type`);
   }
 
+  onHover(info, pickingEvent) {
+    const [mvtLayer] =  this.getSubLayers();
+    return mvtLayer ? mvtLayer.onHover(info, pickingEvent) : super.onHover(info, pickingEvent);
+  }
+
   renderLayers() {
     if (!this.state.tilejson) return [];
 
     const props = {
       ...this.getSubLayerProps(this.props),
+      uniqueIdProperty: this.props.uniqueIdProperty,
       data: this.state.tilejson.tiles
     };
 

--- a/modules/carto/src/layers/carto-layer.js
+++ b/modules/carto/src/layers/carto-layer.js
@@ -25,7 +25,7 @@ export default class CartoLayer extends CompositeLayer {
   }
 
   onHover(info, pickingEvent) {
-    const [mvtLayer] =  this.getSubLayers();
+    const [mvtLayer] = this.getSubLayers();
     return mvtLayer ? mvtLayer.onHover(info, pickingEvent) : super.onHover(info, pickingEvent);
   }
 

--- a/modules/carto/src/layers/carto-sql-layer.js
+++ b/modules/carto/src/layers/carto-sql-layer.js
@@ -9,7 +9,8 @@ const mapsApiProps = {
 
 const defaultProps = {
   ...mapsApiProps,
-  ...CartoLayer.defaultProps
+  ...CartoLayer.defaultProps,
+  uniqueIdProperty: 'cartodb_id'
 };
 
 export default class CartoSQLLayer extends CartoLayer {


### PR DESCRIPTION
check this lines:
`
onHover(info, pickingEvent) {
    const [mvtLayer] = this.getSubLayers();
    return mvtLayer ? mvtLayer.onHover(info, pickingEvent) : super.onHover(info, pickingEvent);
  }
`
Without that, we had lost the autoHighlight functionality because the mvt layer overwrite the onHover method. I can't think of a better way to do it