### PR TITLE
Fix extent prop to allow underzooming with CartoLayers [ch106065]

### DIFF
--- a/docs/api-reference/carto/carto-bqtiler-layer.md
+++ b/docs/api-reference/carto/carto-bqtiler-layer.md
@@ -56,6 +56,7 @@ new deck.carto.CartoBQTilerLayer({});
 
 ## Properties
 
+Inherits all properties from [`MVTLayer`](/docs/api-reference/geo-layers/mvt-layer.md).
 
 ##### `data` (String)
 

--- a/docs/api-reference/carto/carto-sql-layer.md
+++ b/docs/api-reference/carto/carto-sql-layer.md
@@ -58,6 +58,7 @@ new deck.carto.CartoSQLLayer({});
 
 ## Properties
 
+Inherits all properties from [`MVTLayer`](/docs/api-reference/geo-layers/mvt-layer.md).
 
 ##### `data` (String)
 
@@ -90,7 +91,7 @@ Optional. MapConfig version
 * Default: `1.3.1`
 
 
-##### `extent` (String)
+##### `tileExtent` (String)
 
 Optional. Tile extent in tile coordinate space as defined by MVT specification.
 

--- a/modules/carto/src/api/maps-api-client.js
+++ b/modules/carto/src/api/maps-api-client.js
@@ -7,10 +7,10 @@ const REQUEST_GET_MAX_URL_LENGTH = 2048;
  * Obtain a TileJson from Maps API v1
  */
 export async function getMapTileJSON(props) {
-  const {data, bufferSize, version, extent, credentials} = props;
+  const {data, bufferSize, version, tileExtent, credentials} = props;
   const creds = {...getDefaultCredentials(), ...credentials};
 
-  const mapConfig = createMapConfig({data, bufferSize, version, extent});
+  const mapConfig = createMapConfig({data, bufferSize, version, tileExtent});
   const layergroup = await instantiateMap({mapConfig, credentials: creds});
 
   const tiles = layergroup.metadata.tilejson.vector;
@@ -20,7 +20,7 @@ export async function getMapTileJSON(props) {
 /**
  * Create a mapConfig for Maps API
  */
-function createMapConfig({data, bufferSize, version, extent}) {
+function createMapConfig({data, bufferSize, version, tileExtent}) {
   const isSQL = data.search(' ') > -1;
   const sql = isSQL ? data : `SELECT * FROM ${data}`;
 
@@ -34,7 +34,7 @@ function createMapConfig({data, bufferSize, version, extent}) {
         type: 'mapnik',
         options: {
           sql: sql.trim(),
-          vector_extent: extent
+          vector_extent: tileExtent
         }
       }
     ]

--- a/modules/carto/src/layers/carto-sql-layer.js
+++ b/modules/carto/src/layers/carto-sql-layer.js
@@ -4,7 +4,7 @@ import {getMapTileJSON} from '../api/maps-api-client';
 const mapsApiProps = {
   version: '1.3.1', // MapConfig Version (Maps API)
   bufferSize: 1, // MVT buffersize in pixels,
-  extent: 4096 // Tile extent in tile coordinate space (MVT spec.)
+  tileExtent: 4096 // Tile extent in tile coordinate space (MVT spec.)
 };
 
 const defaultProps = {


### PR DESCRIPTION
Related to https://app.clubhouse.io/cartoteam/story/106065/overzoom

It renames the former `extent` prop to `tileExtent` from `CartoLayer` to avoid rewriting the `extent` prop from `TileLayer` that allows underzooming when it is set.

It adds a reminder of that we are inheriting the props from `MVTLayer` to the documentation as well.
