### PR TITLE
add onLoad and onError callbacks to carto-layer.js

### DIFF
--- a/docs/api-reference/carto/carto-bqtiler-layer.md
+++ b/docs/api-reference/carto/carto-bqtiler-layer.md
@@ -74,6 +74,25 @@ Optional. Needed for highlighting a feature split across two or more tiles if no
 
 A string pointing to a tile attribute containing a unique identifier for features across tiles.
 
+### Callbacks
+
+#### `onLoad` (Function, optional)
+
+`onLoad` is called when the request to the CARTO tiler was completed successfully.
+
+- Default: `() => {}`
+
+
+##### `onError` (Function, optional)
+
+`onError` is called when the request to the CARTO tiler failed.
+
+- Default: `console.error`
+
+Receives arguments:
+
+- `error` (`Error`)
+
 
 ## Source
 

--- a/docs/api-reference/carto/carto-sql-layer.md
+++ b/docs/api-reference/carto/carto-sql-layer.md
@@ -108,6 +108,25 @@ Optional. Tile extent in tile coordinate space as defined by MVT specification.
 
 * Default: `4096`
 
+### Callbacks
+
+#### `onLoad` (Function, optional)
+
+`onLoad` is called when the request to the CARTO tiler was completed successfully.
+
+- Default: `() => {}`
+
+
+##### `onError` (Function, optional)
+
+`onError` is called when the request to the CARTO tiler failed.
+
+- Default: `console.error`
+
+Receives arguments:
+
+- `error` (`Error`)
+
 
 ## Source
 

--- a/modules/carto/src/layers/carto-layer.js
+++ b/modules/carto/src/layers/carto-layer.js
@@ -3,7 +3,9 @@ import {MVTLayer} from '@deck.gl/geo-layers';
 
 const defaultProps = {
   data: null,
-  credentials: null
+  credentials: null,
+  onLoad: () => {},
+  onError: err => console.error(err)
 };
 
 export default class CartoLayer extends CompositeLayer {
@@ -16,7 +18,17 @@ export default class CartoLayer extends CompositeLayer {
   updateState({changeFlags}) {
     const {data} = this.props;
     if (changeFlags.dataChanged && data) {
-      this._updateTileJSON();
+      this._updateData();
+    }
+  }
+
+  async _updateData () {
+    const { onError, onLoad } = this.props;
+    try {
+      await this._updateTileJSON();
+      onLoad();
+    } catch (err) {
+      onError(err);
     }
   }
 

--- a/modules/carto/src/layers/carto-layer.js
+++ b/modules/carto/src/layers/carto-layer.js
@@ -23,12 +23,11 @@ export default class CartoLayer extends CompositeLayer {
   }
 
   async _updateData () {
-    const { onError, onLoad } = this.props;
     try {
       await this._updateTileJSON();
-      onLoad();
+      this.props.onLoad();
     } catch (err) {
-      onError(err);
+      this.props.onError(err);
     }
   }
 


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background
This PR covers a need that is present in every PS project. You need to know if the request to the Maps API failed and when it finished loading, so you can catch the error or display a loading spinner when necessary.

<!-- For all the PRs -->
#### Change List
- Change documentation in `carto-bqtiler-layer.md` to include the new callbacks
- Change documentation in `carto-sql-layer.md` to include the new callbacks
- Add callbacks to `carto-layer.js`
